### PR TITLE
Invoke pip as a python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ We'll start off with a fully python project, so if you don’t already have pyth
 
 To install the python libraries we'll be using for our MVP, run the below command in the directory containing this repo on your machine:
 
-`pip install -r requirements.txt`
+```sh
+# Can be py or python3 depending on your system
+python -m pip install -r requirements.txt 
+```
 
 You're free to add to the requirements.txt file if you run into any new libraries you want to add to the project. You're also free to change the version number if you run into conflicts involving the libraries, as some of them may be dated/deprecated. To add to the requirements.txt file, on a new line in the file, simply add the install name of the project followed by '==' followed by the version number, like:
 


### PR DESCRIPTION
I'm not in the team for this but I am in GDSC and wanted to mention this -- it is recommended to invoke `pip` as a `python` module as you are then aware of *which* `python` you are using, especially if you have many environments and multiple versions of `python`. You avoid issues of installing it in another `site-packages` directory, as global `pip` can be linked to a different python executable. This can also help out beginners who may not have `pip` added to `PATH`. It is also just good practice overall. Also adding this in triple backquotes will let you copy it directly which saves a bit of time