### PR TITLE
Add action for pushing backend dockerfile to artifact registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+name: Deploy Backend Dockerfile to Artifact Regitry 
+
+on:
+    push:
+        branches:
+            - 'main'
+  
+jobs:
+    deploy:
+        runs-on: ubuntu-20.04
+        steps:
+        - name: code checkout
+          uses: actions/checkout@v4
+
+        - name: install gcloud cli
+          uses: google-github-actions/setup-gcloud@v0
+          with:
+            project_id: automateml
+            service_account_key: ${{secrets.GCP_SA_KEY}}
+            export_default_credentials: true
+        
+        - name: build and push docker image
+          env:
+            GOOGLE_PROJECT: automateml
+          run: |
+            gcloud auth configure-docker us-central1-docker.pkg.dev
+            docker build -t us-central1-docker.pkg.dev/automateml/backend-docker-image/backend:latest ./backend
+            docker push us-central1-docker.pkg.dev/automateml/backend-docker-image/backend:latest ./backend

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,4 +25,4 @@ jobs:
           run: |
             gcloud auth configure-docker us-central1-docker.pkg.dev
             docker build -t us-central1-docker.pkg.dev/automateml/backend-docker-image/backend:latest ./backend
-            docker push us-central1-docker.pkg.dev/automateml/backend-docker-image/backend:latest ./backend
+            docker push us-central1-docker.pkg.dev/automateml/backend-docker-image/backend:latest 


### PR DESCRIPTION
related to #86
this should (lol maybe wont) push the backend docker image to a repo on our project account. havent tested, might test, will update :)  

we should also be able to use this as a template for all the other docker images we want to push