### PR TITLE
Frontend / Backend pod conflict fixes

### DIFF
--- a/cloud-infra/k8s/backend-deployment.yaml
+++ b/cloud-infra/k8s/backend-deployment.yaml
@@ -5,18 +5,17 @@ metadata:
   labels:
     app: backend
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: backend
-  replicas: 1
   template:
     metadata:
       labels:
         app: backend
     spec:
       containers:
-        - name: backend
-          image: us-central1-docker.pkg.dev/automateml/backend-docker-image/backend:latest
-          ports:
-            - name: http
-              containerPort: 80
+      - name: backend
+        image: us-central1-docker.pkg.dev/automateml/backend-docker-image/backend:latest
+        ports:
+        - containerPort: 8000

--- a/cloud-infra/k8s/backend-service.yaml
+++ b/cloud-infra/k8s/backend-service.yaml
@@ -7,5 +7,6 @@ spec:
     app: backend
   ports:
     - protocol: TCP
-      port: 80
-      targetPort: http
+      port: 8000
+      targetPort: 8000
+  type: LoadBalancer


### PR DESCRIPTION
<img width="1074" alt="image" src="https://github.com/DSC-McMaster-U/Auto-ML/assets/61357467/0e93221d-dd1b-4068-a2bf-49ad1aa22184">

**Changes**
- changed backend pod to require port 8000, instead of 80, so the pods don't try and compete for a port, also the backend is supposed to be that port anyways as its used internally